### PR TITLE
(GH-32) Enabled Deterministic builds

### DIFF
--- a/src/Cake.Gradle.Tests/Cake.Gradle.Tests.csproj
+++ b/src/Cake.Gradle.Tests/Cake.Gradle.Tests.csproj
@@ -10,7 +10,15 @@
 
     <ItemGroup>
         <PackageReference Include="Cake.Testing" Version="0.38.5" />
+        <PackageReference Include="coverlet.msbuild" Version="2.9.0">
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+          <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+          <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
         <PackageReference Include="Moq" Version="4.15.2" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.analyzers" Version="0.10.0" />

--- a/src/Cake.Gradle/Cake.Gradle.csproj
+++ b/src/Cake.Gradle/Cake.Gradle.csproj
@@ -2,9 +2,6 @@
     <PropertyGroup>
         <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <PublishRepositoryUrl>true</PublishRepositoryUrl>
-        <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-        <EmbedUntrackedSources>true</EmbedUntrackedSources>
         <CodeAnalysisRuleSet>$(SolutionDir)/Cake.Gradle.ruleset</CodeAnalysisRuleSet>
     </PropertyGroup>
 

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,0 +1,27 @@
+
+<!-- This target must be imported into Directory.Build.targets -->
+<!-- Workaround. Remove once we're targeting the 3.1.300+ SDK
+https://github.com/dotnet/sourcelink/issues/572 -->
+<Project>
+  <PropertyGroup>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <TargetFrameworkMonikerAssemblyAttributesPath>$([System.IO.Path]::Combine('$(IntermediateOutputPath)','$(TargetFrameworkMoniker).AssemblyAttributes$(DefaultLanguageSourceExtension)'))</TargetFrameworkMonikerAssemblyAttributesPath>
+  </PropertyGroup>
+  <ItemGroup>
+    <EmbeddedFiles Include="$(GeneratedAssemblyInfoFile)"/>
+  </ItemGroup>
+  <ItemGroup>
+    <SourceRoot Include="$(NuGetPackageRoot)" />
+  </ItemGroup>
+
+  <Target Name="CoverletGetPathMap"
+          DependsOnTargets="InitializeSourceRootMappedPaths"
+          Returns="@(_LocalTopLevelSourceRoot)"
+          Condition="'$(DeterministicSourcePaths)' == 'true'">
+    <ItemGroup>
+      <_LocalTopLevelSourceRoot Include="@(SourceRoot)" Condition="'%(SourceRoot.NestedRoot)' == ''"/>
+    </ItemGroup>
+  </Target>
+</Project>


### PR DESCRIPTION
using `.\build.ps1 --target=Enable-Coverlet`

This will generate working coverage-results on CI and so fix #32 