### PR TITLE
(#452) update GitHub runner from macos-12 to macos-13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ windows-2022, ubuntu-22.04, macos-12 ]
+        os: [ windows-2022, ubuntu-22.04, macos-13 ]
 
     env:
       AZURE_PASSWORD: ${{ secrets.AZURE_PASSWORD }}


### PR DESCRIPTION
fixes #452 